### PR TITLE
Fix ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX

### DIFF
--- a/classes/box.c
+++ b/classes/box.c
@@ -185,7 +185,7 @@ PHP_METHOD(Box, setPadded)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
 #endif


### PR DESCRIPTION
Hello, this patch fixes some copy/paste typo. The new macro ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX takes only 5 arguments otherwise compilation fails with the following error on PHP 7.2:

```
...ui/classes/box.c:188:91: error: macro "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX" passed 6 arguments, but takes just 5
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
```