### PR TITLE
Fix ui draw color error

### DIFF
--- a/classes/box.c
+++ b/classes/box.c
@@ -185,7 +185,7 @@ PHP_METHOD(Box, setPadded)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
 #endif

--- a/classes/box.c
+++ b/classes/box.c
@@ -185,7 +185,7 @@ PHP_METHOD(Box, setPadded)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_box_is_padded_info, 0, 0, _IS_BOOL, NULL, 0)
 #endif

--- a/classes/brush.c
+++ b/classes/brush.c
@@ -105,9 +105,9 @@ PHP_METHOD(DrawBrush, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, "UI\Draw\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_brush_get_color_info, 0, 0, IS_OBJECT, "UI\Draw\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_brush_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
 #endif
 ZEND_END_ARG_INFO()
 
@@ -242,7 +242,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_gradient_set_stop_info, 0, 3, _IS
 #endif
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, position, IS_DOUBLE, 0)
-	ZEND_ARG_OBJ_INFO(0, color, UI\Draw\Color, 0)
+	ZEND_ARG_OBJ_INFO(0, color, UI\\Draw\\Color, 0)
 ZEND_END_ARG_INFO()
 
 /* {{{ proto bool UI\Draw\Draw\Brush\Gradient::setStop(int index, double position, UI\Draw\Color color) */

--- a/classes/brush.c
+++ b/classes/brush.c
@@ -105,7 +105,7 @@ PHP_METHOD(DrawBrush, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, UI\\Draw\\Color, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_brush_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
 #endif

--- a/classes/brush.c
+++ b/classes/brush.c
@@ -105,9 +105,9 @@ PHP_METHOD(DrawBrush, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_brush_get_color_info, 0, 0, "UI\Draw\Color", 0)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_brush_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_brush_get_color_info, 0, 0, IS_OBJECT, "UI\Draw\Color", 0)
 #endif
 ZEND_END_ARG_INFO()
 
@@ -242,7 +242,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_gradient_set_stop_info, 0, 3, _IS
 #endif
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, position, IS_DOUBLE, 0)
-	ZEND_ARG_OBJ_INFO(0, color, UI\\Draw\\Color, 0)
+	ZEND_ARG_OBJ_INFO(0, color, UI\Draw\Color, 0)
 ZEND_END_ARG_INFO()
 
 /* {{{ proto bool UI\Draw\Draw\Brush\Gradient::setStop(int index, double position, UI\Draw\Color color) */

--- a/classes/cbutton.c
+++ b/classes/cbutton.c
@@ -96,7 +96,7 @@ PHP_METHOD(ColorButton, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, UI\\Draw\\Color, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
 #endif

--- a/classes/cbutton.c
+++ b/classes/cbutton.c
@@ -96,9 +96,9 @@ PHP_METHOD(ColorButton, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, "UI\Draw\Color", 0)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, IS_OBJECT, "UI\Draw\Color", 0)
 #endif
 ZEND_END_ARG_INFO()
 

--- a/classes/cbutton.c
+++ b/classes/cbutton.c
@@ -96,9 +96,9 @@ PHP_METHOD(ColorButton, setColor)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, "UI\Draw\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, "UI\\Draw\\Color", 0)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, IS_OBJECT, "UI\Draw\Color", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_cbutton_get_color_info, 0, 0, IS_OBJECT, "UI\\Draw\\Color", 0)
 #endif
 ZEND_END_ARG_INFO()
 

--- a/classes/control.c
+++ b/classes/control.c
@@ -76,7 +76,7 @@ ZEND_BEGIN_ARG_INFO_EX(php_ui_control_void_info, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_control_get_parent_info, 0, 0, "UI\\Control", 1)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_control_get_parent_info, 0, 0, UI\\Control, 1)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_control_get_parent_info, 0, 0, IS_OBJECT, "UI\\Control", 1)
 #endif

--- a/classes/matrix.c
+++ b/classes/matrix.c
@@ -130,7 +130,7 @@ PHP_METHOD(DrawMatrix, skew)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_matrix_multiply_info, 0, 1, "UI\\DrawMatrix", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_matrix_multiply_info, 0, 1, UI\\DrawMatrix, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_matrix_multiply_info, 0, 1, IS_OBJECT, "UI\\DrawMatrix", 0)
 #endif

--- a/classes/menu.c
+++ b/classes/menu.c
@@ -61,7 +61,7 @@ PHP_METHOD(Menu, __construct)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_menu_append_info, 0, 0, "UI\\MenuItem", 1)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_menu_append_info, 0, 0, UI\\MenuItem, 1)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_menu_append_info, 0, 0, IS_OBJECT, "UI\\MenuItem", 1)
 #endif
@@ -120,7 +120,7 @@ PHP_METHOD(Menu, appendCheck)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_menu_append_anon_info, 0, 0, "UI\\MenuItem", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_menu_append_anon_info, 0, 0, UI\\MenuItem, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_menu_append_anon_info, 0, 0, IS_OBJECT, "UI\\MenuItem", 0)
 #endif

--- a/classes/window.c
+++ b/classes/window.c
@@ -208,7 +208,7 @@ PHP_METHOD(Window, setSize)
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_window_get_size_info, 0, 0, "UI\\Size", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ui_window_get_size_info, 0, 0, UI\\Size, 0)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_ui_window_get_size_info, 0, 0, IS_OBJECT, "UI\\Size", 0)
 #endif


### PR DESCRIPTION
This fixes errors for return types with ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX.
Specifically noticed in the examples/histogram.php example.
Reproduce-able by running php example/histogram.php